### PR TITLE
Fix: Changes EnginesRegistry to use WhalesIl org instead of IcaliaLabs

### DIFF
--- a/lib/belugas/analyzer/engine_registry.rb
+++ b/lib/belugas/analyzer/engine_registry.rb
@@ -9,7 +9,7 @@ module Belugas
 
       def [](engine_name)
         if dev_mode?
-          { "channels" => { "stable" => "icalialabs/belugas-#{engine_name}:latest" } }
+          { "channels" => { "stable" => "whalesil/belugas-#{engine_name}:latest" } }
         else
           @config[engine_name]
         end


### PR DESCRIPTION
### What does this PR do?

* Changes `EnginesRegistry`class to use `Whalesil`org instead of `Icalialabs` org 